### PR TITLE
Updating setup config - Adding dateutils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,4 @@ packages = find:
 include_package_data = true
 install_requires =
     pyxirr
+    dateutils


### PR DESCRIPTION
Updating dateutils to the setup.cfg. dateutils used in costrecovery.py